### PR TITLE
Add "other" attribute to "aps"

### DIFF
--- a/lib/apnotic/notification.rb
+++ b/lib/apnotic/notification.rb
@@ -3,7 +3,7 @@ require 'apnotic/abstract_notification'
 module Apnotic
 
   class Notification < AbstractNotification
-    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content
+    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :url_args, :mutable_content, :other
 
     private
 
@@ -13,6 +13,7 @@ module Apnotic
         result.merge!(badge: badge) if badge
         result.merge!(sound: sound) if sound
         result.merge!(category: category) if category
+        result.merge!(other: other) if other
         result.merge!('content-available' => content_available) if content_available
         result.merge!('url-args' => url_args) if url_args
         result.merge!('mutable-content' => mutable_content) if mutable_content

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -107,8 +107,8 @@ describe Apnotic::Notification do
             alert:             "Something for you!",
             badge:             22,
             sound:             "sound.wav",
-            other:             { id: 123 },
             category:          "action_one",
+            other:             { id: 123 },
             'content-available' => 1,
             'mutable-content'   => 1
           },

--- a/spec/apnotic/notification_spec.rb
+++ b/spec/apnotic/notification_spec.rb
@@ -14,6 +14,7 @@ describe Apnotic::Notification do
         notification.alert             = "Something for you!"
         notification.badge             = 22
         notification.sound             = "sound.wav"
+        notification.other             = { id: 123 }
         notification.content_available = false
         notification.category          = "action_one"
         notification.custom_payload    = { acme1: "bar" }
@@ -23,6 +24,7 @@ describe Apnotic::Notification do
       it { is_expected.to have_attributes(alert: "Something for you!") }
       it { is_expected.to have_attributes(badge: 22) }
       it { is_expected.to have_attributes(sound: "sound.wav") }
+      it { is_expected.to have_attributes(other: { id: 123 }) }
       it { is_expected.to have_attributes(content_available: false) }
       it { is_expected.to have_attributes(category: "action_one") }
       it { is_expected.to have_attributes(custom_payload: { acme1: "bar" }) }
@@ -92,6 +94,7 @@ describe Apnotic::Notification do
         notification.alert             = "Something for you!"
         notification.badge             = 22
         notification.sound             = "sound.wav"
+        notification.other             = { id: 123 }
         notification.content_available = 1
         notification.category          = "action_one"
         notification.custom_payload    = { acme1: "bar" }
@@ -104,6 +107,7 @@ describe Apnotic::Notification do
             alert:             "Something for you!",
             badge:             22,
             sound:             "sound.wav",
+            other:             { id: 123 },
             category:          "action_one",
             'content-available' => 1,
             'mutable-content'   => 1


### PR DESCRIPTION
In order to keep the full integration with current ios application, we make an extension for apnotic library.

The problem raised because apnotic library doesnt support custom attributes for 'aps' attribute in json as it was in previous gem (apns).

To solve it, we just created a `other` attribute for aps level.



